### PR TITLE
Update INSTALL.md with Numpy version restrictions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@
 - TensorBoard
 - CUDA 11.0+
 - GCC 4.9+
-- NumPy 1.11+
+- 1.11 <= Numpy <= 1.23
 - PyYaml
 - Pandas
 - h5py


### PR DESCRIPTION
np.float is deprecated since Numpy 1.20 and Numpy removed np.float type in 1.24. It will result in evaluation error in ActionFormer, thus we need to limit the Numpy version for ActionFormer.